### PR TITLE
Bugfix: remove `combine="nested"`

### DIFF
--- a/src/esnb/core/esnb_datastore.py
+++ b/src/esnb/core/esnb_datastore.py
@@ -180,7 +180,7 @@ class esnb_datastore(intake_esm.core.esm_datastore):
             _paths,
             use_cftime=True,
             decode_timedelta=True,
-            combine="nested",
+            coords="minimal",
             compat="override",
         )
 


### PR DESCRIPTION
- The open_mfdataset() call had the combine="nested" flag which prevented the timeseries from concatenating properly along the time dimension.