### PR TITLE
Fixed typo in chunk_freq search logic

### DIFF
--- a/src/esnb/core/CaseGroup2.py
+++ b/src/esnb/core/CaseGroup2.py
@@ -150,7 +150,7 @@ def filter_catalog(catalog, variable):
             chunk_freq = preferred_chunkfreqs[0]
         else:
             chunk_freq = ""
-        _cat = _cat.search(chunk_freqs=chunk_freq)
+        _cat = _cat.search(chunk_freq=chunk_freq)
 
     return _cat
 


### PR DESCRIPTION
Uncovered bug when testing the new `CaseGroup2` class with @MitchBushuk's sea ice notebook.

Fixed behavior so that the notebook works properly with the new object.