### PR TITLE
Propogate `z_i` as a coordinate if available

### DIFF
--- a/src/esnb/core/util_xr.py
+++ b/src/esnb/core/util_xr.py
@@ -23,7 +23,13 @@ def open_paths(files, varname=None):
 
     if varname is not None:
         ds = xr.Dataset()
+
         ds[varname] = _ds[varname]
+
+        if "z_i" in _ds.keys():
+            logger.debug("Found `z_i` in dataset; associating it as a coordinate.")
+            ds["z_i"] = _ds["z_i"]
+
         ds.attrs = dict(_ds.attrs)
     else:
         ds = _ds


### PR DESCRIPTION
- If the variable `z_i` (ocean interfaces) is present in the source dataset, propogate it along as a coordinate

Closes #26 