### PR TITLE
Include `aiohttp` in pyproj.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    "aiohttp"
     "importlib_metadata <5.0.0",
     "importlib-resources",
     "intake",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "aiohttp"
+    "aiohttp",
     "importlib_metadata <5.0.0",
     "importlib-resources",
     "intake",


### PR DESCRIPTION
The unit tests require the [aiohttp](https://docs.aiohttp.org/en/stable/) package to run. Including this in the pyproj.toml file. 