### PR TITLE
Override runtime CaseGroup settings with env var

### DIFF
--- a/src/esnb/core/NotebookDiagnostic.py
+++ b/src/esnb/core/NotebookDiagnostic.py
@@ -11,7 +11,13 @@ from esnb.sites import gfdl
 from . import html, util
 from .CaseGroup2 import CaseGroup2
 from .RequestedVariable import RequestedVariable
-from .util2 import flatten_list, generate_tempdir_path, read_json, reset_encoding
+from .util2 import (
+    flatten_list,
+    generate_tempdir_path,
+    process_key_value_string,
+    read_json,
+    reset_encoding,
+)
 from .VirtualDataset import VirtualDataset
 
 # import warnings
@@ -451,10 +457,13 @@ class NotebookDiagnostic:
 
         if esnb_case_data is not None:
             logger.info("Converting case override data to dict")
-            logger.info(
-                "This feature is not fully implemented; falling back to original groups"
-            )
-            groups = groups
+            override = process_key_value_string(esnb_case_data)
+            logger.info("Creating new CaseGroup2 object")
+            groups = [CaseGroup2(override["PP_DIR"], date_range=override["date_range"])]
+            # logger.info(
+            #    "This feature is not fully implemented; falling back to original groups"
+            # )
+            # groups = groups
         elif esnb_case_file is not None:
             logger.info(f"Reading case override settings from file: {esnb_case_file}")
             if not os.path.exists(esnb_case_file):

--- a/src/esnb/data/input_timeslice_test.yml
+++ b/src/esnb/data/input_timeslice_test.yml
@@ -20,7 +20,8 @@ case_list:
 
 ### Data location settings ###
 # Required: full or relative path to ESM-intake catalog header file
-DATA_CATALOG: "/glade/u/home/bundy/diag/mdtf/catalogs/esm_catalog_CESM_timeslice_mdtfv3.20241107.json"
+#DATA_CATALOG: "/glade/u/home/bundy/diag/mdtf/catalogs/esm_catalog_CESM_timeslice_mdtfv3.20241107.json"
+DATA_CATALOG: "/home/jpk/Desktop/esm_catalog_CESM_timeslice_mdtfv3.20241107.json"
 
 # Optional: Parent directory containing observational data used by individual PODs.
 # If defined, the framework assumes observational data is in OBS_DATA_ROOT/[POD_NAME]

--- a/tests/test_util2.py
+++ b/tests/test_util2.py
@@ -12,6 +12,7 @@ from esnb.core.util2 import (
     infer_source_data_file_types,
     initialize_cases_from_source,
     xr_date_range_to_datetime,
+    process_key_value_string,
 )
 
 # TODO: Add tests for `read_json`, `reset_encoding`
@@ -87,5 +88,31 @@ def test_infer_source_data_file_types_2():
     assert infer_source_data_file_types(test_paths_2) == "unix_file"
 
 
-# test_infer_source_data_file_types_1()
-# test_infer_source_data_file_types_2()
+def test_process_key_value_string_1():
+    keyval_string = "PP_DIR:/path/to/some/dir,date_range:(1958-01-01,1977-12-31),extras:[123,'456',789]"
+    result = process_key_value_string(keyval_string)
+    assert isinstance(result, dict)
+
+
+def test_process_key_value_string_2():
+    keyval_string = "PP_DIR:/path/to/some/dir,date_range:(1958-01-01,1977-12-31),extras:[123,'456',789]"
+    result = process_key_value_string(keyval_string)
+    assert isinstance(result["date_range"], tuple)
+
+
+def test_process_key_value_string_3():
+    keyval_string = "PP_DIR:/path/to/some/dir,date_range:(1958-01-01,1977-12-31),extras:[123,'456',789]"
+    result = process_key_value_string(keyval_string)
+    assert isinstance(result["extras"], list)
+
+
+def test_process_key_value_string_4():
+    keyval_string = "PP_DIR:/path/to/some/dir,date_range:(1958-01-01,1977-12-31),extras:[123,'456',789]"
+    result = process_key_value_string(keyval_string)
+    assert isinstance(result["date_range"][0], str)
+
+
+def test_process_key_value_string_5():
+    keyval_string = "PP_DIR:/path/to/some/dir,date_range:(1958-01-01,1977-12-31),extras:[123,'456',789]"
+    result = process_key_value_string(keyval_string)
+    assert isinstance(result["extras"][0], str)


### PR DESCRIPTION
- A key-value string can now be passed via `ESNB_CASE_DATA`
- If provided, these values will be used to initialize a new CaseGroup2 object that takes precedence over anything previously defined in the notebook
- Added utility to parse a key-val strings