### PR TITLE
Added interface layer for dask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp",
+    "dask",
+    "dask-jobqueue",
     "importlib_metadata <5.0.0",
     "importlib-resources",
     "intake",

--- a/src/esnb/__init__.py
+++ b/src/esnb/__init__.py
@@ -11,6 +11,7 @@ from .core.CaseGroup2 import CaseGroup2
 from .core.esnb_datastore import esnb_datastore
 from .core.NotebookDiagnostic import NotebookDiagnostic
 from .core.RequestedVariable import RequestedVariable
+from .core.util_dask import init_dask_cluster
 
 __all__ = [
     "core",
@@ -24,6 +25,7 @@ __all__ = [
     "esnb_datastore",
     "NotebookDiagnostic",
     "RequestedVariable",
+    "init_dask_cluster",
     "nbtools",
 ]
 

--- a/src/esnb/core/__init__.py
+++ b/src/esnb/core/__init__.py
@@ -8,6 +8,7 @@ from . import (
     util,
     util2,
     util_catalog,
+    util_dask,
     util_mdtf,
     util_xr,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "util",
     "util2",
     "util_case",
+    "util_dask",
     "util_catalog",
     "util_mdtf",
     "util_xr",

--- a/src/esnb/core/util_dask.py
+++ b/src/esnb/core/util_dask.py
@@ -1,0 +1,64 @@
+import inspect
+import logging
+import os
+
+from dask.distributed import Client, LocalCluster
+
+logger = logging.getLogger(__name__)
+
+
+def _local_cluster(**kwargs):
+    sig = inspect.signature(LocalCluster)
+    params = sig.parameters
+    valid_args = [name for name, param in params.items()]
+
+    ignored_args = []
+    for k, v in kwargs.items():
+        if k not in valid_args:
+            ignored_args.append(k)
+
+    if len(ignored_args) > 0:
+        for x in ignored_args:
+            del kwargs[x]
+        logger.warning(f"Ignoring options for LocalCluster: {ignored_args}")
+
+    cluster = LocalCluster(**kwargs)
+    client = Client(cluster)
+    logger.info(f"Initializing local dask cluster: {cluster.dashboard_link}")
+    return (cluster, client)
+
+
+def init_dask_cluster(site="local", **kwargs):
+    if "portdash" in kwargs.keys():
+        kwargs["dashboard_address"] = f":{kwargs['portdash']}"
+        del kwargs["portdash"]
+
+    if site == "local":
+        cluster, client = _local_cluster(**kwargs)
+    elif site == "gfdl_ppan":
+        from esnb.sites.gfdl import dask_cluster_ppan
+
+        cluster, client = dask_cluster_ppan(**kwargs)
+
+        if cluster is None:
+            logger.warning("An error occured; Falling back to dask LocalCluster")
+            cluster, client = _local_cluster(**kwargs)
+
+    else:
+        raise ValueError(f"Unrecognized Dask Site: {site}")
+
+    return (cluster, client)
+
+
+def init_dask_cluster_test(**kwargs):
+    options = {
+        "site": "gfdl_ppan",
+        "walltime": "24:00:00",
+        "highmem": True,
+        "memory": "48GB",
+        "portdash": os.getuid() + 6047,
+    }
+
+    options = {**options, **kwargs}
+
+    return init_dask_cluster(**options)


### PR DESCRIPTION
- New utility module: `util_dask.py`
- Added a generic function `init_dask_cluster()` to start a dask cluster and client instance
- Flexibility to make it site-specific; GFDL PPAN cluster added
- Added a blocking call to `cluster.wait_for_workers()` to ensure that workers are availble for computation before proceeding.
- Utility will always fall back to a LocalCluster instance if the site-specific instances fail to initialize